### PR TITLE
feat: expand backtest parameters

### DIFF
--- a/src/components/charts/PriceChart.tsx
+++ b/src/components/charts/PriceChart.tsx
@@ -4,7 +4,7 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, ReferenceD
 type Candle = { openTime: string; close: number }
 
 
-type Trade = { time: string; type: 'BUY'|'SELL' }
+type Trade = { time: string; type: 'BUY'|'SELL'; price: number }
 
 
 export default function PriceChart({ candles, trades }:{ candles: Candle[]; trades?: Trade[] }){
@@ -17,7 +17,7 @@ return (
 <Tooltip />
 <Line type="monotone" dataKey="close" dot={false} />
 {trades?.map((t,i)=> (
-<ReferenceDot key={i} x={t.time} y={candles.find(c=>c.openTime===t.time)?.close} r={4} label={t.type==='BUY'?'B':'S'} />
+<ReferenceDot key={i} x={t.time} y={t.price} r={4} label={t.type==='BUY'?'B':'S'} />
 ))}
 </LineChart>
 </ResponsiveContainer>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -18,7 +18,8 @@ type BacktestResult = {
     profitFactor: number
     trades: number
   }
-  trades: { time: string; type: 'BUY' | 'SELL' }[]
+  equity: { time: string; value: number }[]
+  trades: { time: string; type: 'BUY' | 'SELL'; price: number }[]
 }
 
 type FormValues = {
@@ -28,6 +29,11 @@ type FormValues = {
   strategy: string
   fast: number
   slow: number
+  signal: number
+  rsi: number
+  bb: number
+  initialCapital: number
+  positionSize: number
 }
 
 export default function Dashboard() {
@@ -45,6 +51,11 @@ export default function Dashboard() {
       strategy: 'ema_cross',
       fast: 9,
       slow: 21,
+      signal: 9,
+      rsi: 14,
+      bb: 20,
+      initialCapital: 10000,
+      positionSize: 1,
     },
   })
 
@@ -88,9 +99,15 @@ export default function Dashboard() {
       body: JSON.stringify({
         symbol: values.symbol,
         interval: values.interval,
+        limit: Number(values.limit),
         strategy: values.strategy,
         fast: Number(values.fast),
         slow: Number(values.slow),
+        signal: Number(values.signal),
+        rsi: Number(values.rsi),
+        bb: Number(values.bb),
+        initialCapital: Number(values.initialCapital),
+        positionSize: Number(values.positionSize),
       }),
     })
     setResult(res)
@@ -137,6 +154,31 @@ export default function Dashboard() {
             placeholder="slow"
             {...register('slow', { valueAsNumber: true })}
           />
+          <Input
+            type="number"
+            placeholder="signal"
+            {...register('signal', { valueAsNumber: true })}
+          />
+          <Input
+            type="number"
+            placeholder="rsi"
+            {...register('rsi', { valueAsNumber: true })}
+          />
+          <Input
+            type="number"
+            placeholder="bb"
+            {...register('bb', { valueAsNumber: true })}
+          />
+          <Input
+            type="number"
+            placeholder="capital"
+            {...register('initialCapital', { valueAsNumber: true })}
+          />
+          <Input
+            type="number"
+            placeholder="size"
+            {...register('positionSize', { valueAsNumber: true })}
+          />
           <Button type="submit">1) Ingerir &amp; Carregar</Button>
         </form>
       </Card>
@@ -177,6 +219,7 @@ export default function Dashboard() {
           trades={result?.trades?.map((t) => ({
             time: t.time,
             type: t.type,
+            price: t.price,
           }))}
         />
       </Card>


### PR DESCRIPTION
## Summary
- support full backtest options including signal, RSI, Bollinger Bands, capital and position size
- plot trade markers using prices from backend

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68a8e21a4ab4832f8589f163b65ffbc6